### PR TITLE
Update F103C8.ld

### DIFF
--- a/F103C8.ld
+++ b/F103C8.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 


### PR DESCRIPTION
libopencm3 does not have libopencm3_stm32f1.ld anymore, they have only one common linker file for all targets